### PR TITLE
412 recovery integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ test_servers/*
 features.zip
 *.apk
 *.html
+*.txt
+*/__pycache__
+scripts/ccc
+scripts/checkout_cross_request_repo.py

--- a/features/step_definitions/hq_api.rb
+++ b/features/step_definitions/hq_api.rb
@@ -9,11 +9,36 @@ Then (/^I store most recent form submission time$/) do
   system("python3 commcare-hq-api/utils.py store_latest_form")
 end
 
+Then (/^I stage a recovery sync$/) do
+  system("python3 scripts/ccc invalidate")
+end
+
 Then (/^I check that (\d+) attachments for latest form are on HQ$/) do |attachment_count|
   # since the form.xml is counted as an attachment, increment count
   attachment_count_including_form = attachment_count.to_i + 1
   correct_attachment_count = system("python3 commcare-hq-api/utils.py assert_attachments #{attachment_count_including_form}")
   if not correct_attachment_count
     fail("Submitted form didn't contain the expected #{attachment_count} attachments")
+  end
+end
+
+Then (/^I store case list count$/) do
+  sleep(1) # TODO: better blocking while case list loads
+  list_count = query("ListView","getAdapter","getCount").first
+  file = open("case_list_count.txt", 'w')
+  file.write(list_count)
+  file.close
+end
+
+Then (/^I assert case list count against stored count$/) do
+  sleep(1) # TODO: better blocking while case list loads
+  list_count = query("ListView","getAdapter","getCount").first
+  file = open("case_list_count.txt", 'r')
+  expected_count = file.readline()
+  file.close
+  File.delete("case_list_count.txt")
+
+  if list_count.to_i != expected_count.to_i
+    fail("Expected to see %s entries but got %s" % [expected_count, list_count])
   end
 end

--- a/features/sync_recovery.feature
+++ b/features/sync_recovery.feature
@@ -9,7 +9,7 @@ Scenario: Make sure recovery syncs work
 
     # count cases
     Then I select module "Visit"
-    Then I remember case list count
+    Then I store case list count
 
     # perform 'recovery' sync
     Then I go back to the home screen
@@ -17,5 +17,6 @@ Scenario: Make sure recovery syncs work
     Then I sync
 
     # make sure the same number of cases are around
+    Then I press start
     Then I select module "Visit"
-    Then I assert case list count
+    Then I assert case list count against stored count

--- a/features/sync_recovery.feature
+++ b/features/sync_recovery.feature
@@ -1,0 +1,21 @@
+Feature: Perform Recovery Sync
+@Integration
+Scenario: Make sure recovery syncs work
+    Then I install the ccz app at "case_claim.ccz"
+
+    # create a case with one user
+    Then I login with username "test" and password "123"
+    Then I press start
+
+    # count cases
+    Then I select module "Visit"
+    Then I remember case list count
+
+    # perform 'recovery' sync
+    Then I go back to the home screen
+    Then I stage a recovery sync
+    Then I sync
+
+    # make sure the same number of cases are around
+    Then I select module "Visit"
+    Then I assert case list count

--- a/scripts/get_script_dependencies.sh
+++ b/scripts/get_script_dependencies.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 wget https://raw.githubusercontent.com/dimagi/mobile-deploy/master/checkout_cross_request_repo.py
+wget https://raw.githubusercontent.com/dimagi/commcare-android/master/scripts/ccc


### PR DESCRIPTION
Check that sync recovery results in the same number of cases.

Requires running `./scripts/get_script_dependencies.sh` beforehand to pull the latest version of `ccc` from the `commcare-android` repo.

Depends on https://github.com/dimagi/commcare-android/pull/1374 being merged