### PR TITLE
Use ruby's bundler to install Calabash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# Contents of Gemfile
+source "https://rubygems.org"
+
+gem 'calabash-android'
+gem 'cucumber'

--- a/run
+++ b/run
@@ -22,16 +22,16 @@ rm "commcare.apk"
 if [ "$BUILD" == "master" ]; then
   echo "downloading latest master apk from jenkins"
   wget "https://jenkins.dimagi.com/job/commcare-android/lastSuccessfulBuild/artifact/commcare-android/build/outputs/apk/commcare-android-commcare-release.apk" -O commcare.apk
-  calabash-android resign commcare.apk
+  bundler exec calabash-android resign commcare.apk
 elif [ "$BUILD" == "version" ]; then
   echo "downloading latest master apk from jenkins"
   wget "https://jenkins.dimagi.com/job/commcare-android-$VERSION/lastSuccessfulBuild/artifact/commcare-android/build/outputs/apk/commcare-android-commcare-release.apk" -O commcare.apk
-  calabash-android resign commcare.apk
+  bundler exec calabash-android resign commcare.apk
 elif [ "$BUILD" == "release" ]; then
   echo "downloading latest release apk from jenkins"
   URL=$(python3 scripts/get_latest_release_url.py)
   wget $URL -O commcare.apk
-  calabash-android resign commcare.apk
+  bundler exec calabash-android resign commcare.apk
 else
   echo "building from pull request"
   ./scripts/build_pr_apk.py $BUILD
@@ -46,4 +46,4 @@ if [[ $TAG = \@* ]] ; then
 else
   FEATURE=$TAG
 fi
-calabash-android run commcare.apk $FEATURE --format junit --out reports
+bundler exec calabash-android run commcare.apk $FEATURE --format junit --out reports


### PR DESCRIPTION
It is hard to keep calabash up to date accross different environments. The [Calabash docs ](https://github.com/calabash/calabash-android/blob/master/documentation/installation.md#installation-1) recommend using Ruby's `bundler` command. 

to install:
`gem install bundler`
`bundle install --path vendor/bundle`
(the `--path vendor/bundle` installs the packages in `.vendor/bundle`)

to run:
`bundle exec any_normal_calabash_command`

to update:
`bundle update`