### PR TITLE
Test syncing with external app

### DIFF
--- a/features/external_sync.feature
+++ b/features/external_sync.feature
@@ -1,0 +1,9 @@
+Feature: Verify that syncing with a deleted user errors correctly
+
+@Integration @2.31
+Scenario: Create and restore a user, then delete and sync
+    Then I uninstall the "com.dimagi.test.external" apk app
+    Then I install the "commcare-tester-app-debug" apk
+    Then I open the "com.dimagi.test.external/com.dimagi.test.external.ExternalAppActivity" app
+    Then I touch the "ACQUIRE COMMCARE KEY" text
+    Then I touch the "Grant Access" text

--- a/features/step_definitions/installation.rb
+++ b/features/step_definitions/installation.rb
@@ -33,3 +33,7 @@ end
 Then (/^I install the "([^\"]*)" apk$/) do |apk|
   system("adb install -r features/resource_files/apks/%s.apk" % apk)
 end
+
+Then (/^I open the "([^\"]*)" app$/) do |path|
+  system("adb shell am start -n %s" % path)
+end


### PR DESCRIPTION
@phillipm I'm having trouble getting Calabash to see the external application - always just times out waiting for the element. Do I have to do anything besides run the easy_install command?