### PR TITLE
Multiple Apps Tests

### DIFF
--- a/features/multiple_apps.feature
+++ b/features/multiple_apps.feature
@@ -1,0 +1,118 @@
+Feature: Multiple Applications Test
+@QA @Multiple_Apps
+Scenario: Install Multiple Applications to Device
+	Then I install the ccz app at "languages.ccz"
+	Then I select "Go to App Manager" menu item
+	Then I press "Install An App" 
+	Then I wait for progress
+
+	#Install using app code via Application Manager
+	Then I install the app using app manager at "2fGi0M8"
+	Then I see the text "Language Test"
+	Then I see the text "Test: List Searching"
+
+	#Cannot install more than 2 apps
+	Then I press "Install An App"
+	Then I see the text "You have reached your limit"
+	Then I press "Back to App Manager"
+	Then I wait for progress
+
+	#Confirm 2 apps on Login Screen
+	Then I go back
+	Then I see the app selector button
+	Then I press "Test: List Searching"
+	Then I press "Language Test"
+	Then I wait for progress
+	Then I see the app selector button
+
+	#Archive app and confirm 1 app on login screen
+	Then I select "Go to App Manager" menu item
+	Then I wait for progress
+	Then I press "Test: List Searching"
+	Then I press "Archive"
+	Then I see the text "Unarchive"
+	Then I go back
+	Then I go back
+	Then I don't see the app selector button
+
+	#Unarchive the first application
+	Then I select "Go to App Manager" menu item 
+	Then I wait for progress
+	Then I press "Test: List Searching"
+	Then I press "Unarchive"
+	Then I see the text "Archive"
+
+	Then I go back
+	Then I wait for progress
+	Then I go back
+	Then I see the app selector button
+
+	#Update Application
+	Then I select "Go to App Manager" menu item
+	Then I press "Language Test"
+	Then I see the text "App Version: 102"
+	Then I see the text "Uninstall"
+	Then I see the text "Update"
+	
+	Then I press "Update"
+	Then I see the text "Current version: 102"
+	Then I press "Update to version 103"
+	Then I wait for progress
+
+	#Assert to confirm all options appear
+	Then I see the text "App Version: 103"
+	Then I see the text "Uninstall"
+	Then I see the text "Update"
+
+	#Uninstall to test functionality and prep for next test
+	Then I press "Uninstall"
+	Then I see the text "Uninstalling your app"
+	Then I press "OK"
+	Then I wait for progress
+	Then I see the text "Welcome back! Please log in."
+	Then I don't see the app selector button
+
+	#Confirm in app manager
+	Then I select "Go to App Manager" menu item
+	Then I see the text "Test: List Searching"
+	Then I don't see the text "Language Test"
+
+	Scenario: Validate MM
+	#Installing app for MM tests
+	Then I select "Go to App Manager" menu item
+	Then I wait for progress
+	Then I press "Install An App"
+	Then I install the app using app manager at "2gJtNLa"
+
+	#Press Retry and confirm nothing changes
+	Then I press "Retry"
+	Then I see the text "Skip For Now"
+	Then I see the text "Retry"
+
+	Then I press "Skip For Now"
+	Then I see "Media Not Verified"
+	Then I press "OK"
+
+	#Confirm only 1 app on login screen
+	Then I go back
+	Then I go back
+	Then I don't see the app selector button
+	
+	#Confirm you can Install Multimedia
+	Then I select "Go to App Manager" menu item
+	Then I press "Multiple Apps"
+	Then I press "Validate Multimedia"
+	Then I access Install Multimedia
+	Then I install the multimedia at "commcare.zip"
+
+	#Confirm 2 apps on login screen
+	Then I see the text "Multiple Apps"
+	Then I go back
+	Then I wait for progress
+	Then I go back
+	Then I see the app selector button 
+	
+	#Confirm validate MM gone from App Manager
+	Then I select "Go to App Manager" menu item
+	Then I press "Multiple Apps"
+	Then I don't see "Validate Multimedia"

--- a/features/step_definitions/multiple_apps.rb
+++ b/features/step_definitions/multiple_apps.rb
@@ -1,0 +1,39 @@
+#Install Multimedia
+#Clear_text step because I've found the field remains populated after the first time the file is pushed.
+Then (/^I install the multimedia at "([^\"]*)"$/) do |path|
+  push("features/resource_files/multimedia/%s" % path, "/sdcard/%s" % path)
+  step("I wait for progress")
+  clear_text("id:'screen_multimedia_inflater_location")
+  step("I enter \"storage/emulated/0/%s\" into input field number 1" % path)
+  hide_soft_keyboard()
+
+  tap_when_element_exists("* {text CONTAINS[c] 'Install Multimedia'}")
+  step("I wait for progress")
+end
+
+# perform install through app manager. Same steps as install app, just without the wait step at the end. It causes test to fail through app manager.
+Then (/^I install the app using app manager at "([^\"]*)"$/) do |url|
+  step("I scroll until I see the \"enter_app_location\" id")
+  tap_when_element_exists("* id:'enter_app_location'")
+  enter_text("android.widget.EditText id:'edit_profile_location'", url)
+  tap_when_element_exists("* id:'start_install'")
+  step("I scroll until I see the \"btn_start_install\" id")
+  tap_when_element_exists("* id:'btn_start_install'")
+  wait_for_element_exists("* id:'install_app_button'")
+end
+
+#Multiple Apps Selector
+Then (/^I don't see the app selector button$/) do
+	wait_for_element_does_not_exist("* id:'app_selection_spinner'")
+end
+
+Then (/^I see the app selector button$/) do
+	wait_for_element_exists("* id:'app_selection_spinner'")
+end
+
+#Then I select "Install Multimedia" does not work for this option. Janky workaround
+Then (/^I access Install Multimedia$/) do 
+  touch("com.android.internal.view.menu.ActionMenuPresenter$OverflowMenuButton marked:'More options'")
+  sleep 1
+  tap_when_element_exists("* {text CONTAINS[c] 'Install Multimedia'}")
+end


### PR DESCRIPTION
Could not automate 2 portions of the test plan:

1) Login to 1st app > minimize CommCare > Open App Manager > Install 2nd app (Or update) > Receive message that you will be logged out of 1st app. Not sure how to minimize CommCare and then open App Manager. Would this be possible?

2) Superuser settings. Need to scan barcode, which can't be automated. 