### PR TITLE
change select form -> select module

### DIFF
--- a/features/dialogs.feature
+++ b/features/dialogs.feature
@@ -7,7 +7,9 @@ Scenario: Make sure dialogs create, dismiss, and rotate correctly
     Then I press start
     Then I select module "Errors"
 
-    Then I select form "Error on open"
+    # Even though this is a form, need to use "select module" since nav pane isn't focused
+    # due to the error message
+    Then I select module "Error on open"
 
     Then I see the text "Error Occurred"
     Then I rotate to landscape


### PR DESCRIPTION
This was failing on AWS because the nav_pane element was obscured by the error message. "select module" doesn't expect this to be there. 