### PR TITLE
Test alternate update endpoints

### DIFF
--- a/features/app_update.feature
+++ b/features/app_update.feature
@@ -6,7 +6,7 @@ Scenario: Ensure app update can be obtained from HQ
     Then I login with username "user_with_no_data" and password "123"
 
     # Make sure the update endpoint is set to "Latest starred build"
-    Then I select the "Settings" menu item
+    Then I select "Settings" menu item
     Then I touch the "Update Options" text
     Then I touch the "Latest starred build" text
     Then I go back to the home screen
@@ -73,7 +73,7 @@ Scenario: Ensure app update can be obtained from HQ
 
     # Change the update endpoint to "Latest build" and update again 
     Then I go back to the home screen
-    Then I select the "Settings" menu item
+    Then I select "Settings" menu item
     Then I touch the "Update Options" text
     Then I touch the "Latest build" text
     Then I go back to the home screen
@@ -87,7 +87,7 @@ Scenario: Ensure app update can be obtained from HQ
 
     # Change the update endpoint to "Latest saved state" and update again 
     Then I go back to the home screen
-    Then I select the "Settings" menu item
+    Then I select "Settings" menu item
     Then I touch the "Update Options" text
     Then I touch the "Latest saved state" text
     Then I go back to the home screen
@@ -96,7 +96,7 @@ Scenario: Ensure app update can be obtained from HQ
     Then I apply the update
     Then I login with username "user_with_no_data" and password "123"
     Then I press start
-    Then I do not see the text "Module One, renamed"
+    Then I don't see the text "Module One, renamed"
     Then I see the text "Module Two, renamed"
 
     # turn off wifi and try updating

--- a/features/app_update.feature
+++ b/features/app_update.feature
@@ -5,6 +5,12 @@ Scenario: Ensure app update can be obtained from HQ
     Then I install the ccz app at "app_update.ccz"
     Then I login with username "user_with_no_data" and password "123"
 
+    # Make sure the update endpoint is set to "Latest starred build"
+    Then I select the "Settings" menu item
+    Then I touch the "Update Options" text
+    Then I touch the "Latest starred build" text
+    Then I go back to the home screen
+    
     # check base form content
     Then I press start
     Then I see the text "Module Three"
@@ -64,6 +70,34 @@ Scenario: Ensure app update can be obtained from HQ
     Then I see the text "Current version: 11"
     Then I touch the "Recheck" text
     Then I see the text "Current version: 11"
+
+    # Change the update endpoint to "Latest build" and update again 
+    Then I go back to the home screen
+    Then I select the "Settings" menu item
+    Then I touch the "Update Options" text
+    Then I touch the "Latest build" text
+    Then I go back to the home screen
+    Then I select "Update App" menu item
+    Then I wait to see "Update to version"
+    Then I see the text "version 12"
+    Then I apply the update
+    Then I login with username "user_with_no_data" and password "123"
+    Then I press start
+    Then I see the text "Module One, renamed"
+
+    # Change the update endpoint to "Latest saved state" and update again 
+    Then I go back to the home screen
+    Then I select the "Settings" menu item
+    Then I touch the "Update Options" text
+    Then I touch the "Latest saved state" text
+    Then I go back to the home screen
+    Then I select "Update App" menu item
+    Then I wait to see "Update to version"
+    Then I apply the update
+    Then I login with username "user_with_no_data" and password "123"
+    Then I press start
+    Then I do not see the text "Module One, renamed"
+    Then I see the text "Module Two, renamed"
 
     # turn off wifi and try updating
     Then I go back to the home screen

--- a/features/resource_files/ccz-key.txt
+++ b/features/resource_files/ccz-key.txt
@@ -1,0 +1,12 @@
+app_update.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/0841e3049fd00508782eb4f996e36611/
+case_claim.ccz --> 
+case_sharing.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/74f57b9558045e21329034d67ad71862/
+ccqa.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/db79603c9810a2ed3f637ebaf518bd1e/
+fingerprinting.ccz -->
+fixtures.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/8895d9d9adce7f31ae4a77ad8d29cd44/
+integration_test_app.ccz -->
+languages.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/9814884c597380a16767a2746a431ff1/
+session_expiration.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/9946ed17f21fbf2d8e950df12aa2a6b7/
+settings_sheet_tests.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/3a8891c60af83ac44f2dc242f3e7fe2c/
+test_list_search.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/a5c7bb6839b4f31463827956e80cf4a5/
+test_select_filters.ccz --> https://www.commcarehq.org/a/ui-tests/apps/view/7d5921a03ba61e4b048458590fbb3001/


### PR DESCRIPTION
Relevant as of 2.33, this updates the app_update.feature test to include tests for the 2 alternative update endpoints.

Also adds a text file to track the HQ app url that each .ccz file corresponds to. I left a few blank because I'm not sure where Phillip put the apps for the integration tests; we should try to find them at some point.