### PR TITLE
Don't run unreleased features in integration tests

### DIFF
--- a/features/app_update.feature
+++ b/features/app_update.feature
@@ -1,6 +1,6 @@
 Feature: App update test
 # Not AWS due to airplane mode
-@Integration
+@Integration @2.34
 Scenario: Ensure app update can be obtained from HQ 
     Then I install the ccz app at "app_update.ccz"
     Then I login with username "user_with_no_data" and password "123"

--- a/features/fail.feature
+++ b/features/fail.feature
@@ -1,0 +1,7 @@
+@Integration @2.34
+Feature: Fail Tests
+
+  Scenario: This should not be run
+    # This should fail if its called - it should not be called
+    Then I install the ccz app at "fail.ccz"
+    Then I login with username "user_with_no_data" and password "123"

--- a/features/fail.feature
+++ b/features/fail.feature
@@ -1,7 +1,0 @@
-@Integration @2.34
-Feature: Fail Tests
-
-  Scenario: This should not be run
-    # This should fail if its called - it should not be called
-    Then I install the ccz app at "fail.ccz"
-    Then I login with username "user_with_no_data" and password "123"

--- a/run
+++ b/run
@@ -14,6 +14,13 @@ BUILD=$1
 TAG=$2
 VERSION=$3
 
+# Find next version number, IE 2.33 -> 2.34
+IFS='.' read -a VERSION_ARRAY <<< "$3"
+MAJOR_VERSION="${VERSION_ARRAY[0]}"
+MINOR_VERSION="${VERSION_ARRAY[1]}"
+NEW_MINOR_VERSION="$((MINOR_VERSION+1))"
+NEW_VERSION_TAG="${MAJOR_VERSION}.${NEW_MINOR_VERSION}"
+
 rm "*.png"
 rm -rf "reports"
 rm "commcare.apk"
@@ -50,7 +57,7 @@ adb shell input keyevent 82
 
 # run tests
 if [[ $TAG = \@* ]] ; then
-  FEATURE="--tags $TAG"
+  FEATURE="--tags $TAG --tags ~@${NEW_VERSION_TAG}"
 else
   FEATURE=$TAG
 fi


### PR DESCRIPTION
Provided that Jenkins can pass in the current released version as the third parameter (this is happened at the moment) then this change will cause all features tagged with the NEXT release number not to run. So for example if we are currently on release 2.33 and you write a test for a feature targeting 2.34, then tagging your test with @2.34 would cause this test to be skipped until 2.34 is released. 

~Don't pull until Jenkins can be configured~

I setup an environment var COMMCARE_RELEASE_VERSION to do this and confirmed working on the app_updates feature. This can be pulled and then integration tests can target master