### PR TITLE
Re-implement retry framework

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -3,7 +3,7 @@ def notify = false
 // Number of times to retry a failed test
 def retries = 3
 // Pool of devices on AWS to run on
-def poolArray = ['galaxy']
+def poolArray = ['tab10']
 // Job to copy the tested APK from
 def cc_android_job = 'commcare-android'
 

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -41,7 +41,7 @@ node {
                     def stagePassed = false
                     stage(stageString) {
                         count = 0
-                        while (count < 3 and !stagePassed) {
+                        while (count < 3 & !stagePassed) {
                             echo "Testing ${stageString} try number ${count} tag ${tag}"
                             step([$class: 'AWSDeviceFarmRecorder',
                                                 projectName: 'commcare-odk',

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -3,9 +3,11 @@ def notify = false
 // Number of times to retry a failed test
 def retries = 3
 // Pool of devices on AWS to run on
-def poolArray = ['tab10']
+def poolArray = ['moto']
 // Job to copy the tested APK from
 def cc_android_job = 'commcare-android'
+
+def buildPassing = true
 
 node {
     stage('test') {
@@ -35,32 +37,46 @@ node {
             // times on failures
             for (pool in poolArray) {
                 for (tag in tagArray) {
-                    def stageString = "Testing ${tag} on ${pool}"
-                    try {
-                        stage(stageString) {
-                            count = 1
-                            retry(retries) {
-                                echo "Testing ${stageString} try number ${count} tag ${tag}"
-                                step([$class: 'AWSDeviceFarmRecorder',
-                                                    projectName: 'commcare-odk',
-                                                    devicePoolName: pool,
-                                                    runName: stageString,
-                                                    appArtifact: 'app-commcare-debug.apk',
-                                                    testToRun: 'CALABASH',
-                                                    calabashFeatures: 'aws/features.zip',
-                                                    calabashTags: tag,
-                                                    isRunUnmetered: true,
-                                                    storeResults: true,
-                                                ])
+                    def stageString = "${tag} on ${pool}"
+                    def stagePassed = false
+                    stage(stageString) {
+                        count = 0
+                        while (count < 3 and !stagePassed) {
+                            echo "Testing ${stageString} try number ${count} tag ${tag}"
+                            step([$class: 'AWSDeviceFarmRecorder',
+                                                projectName: 'commcare-odk',
+                                                devicePoolName: pool,
+                                                runName: stageString,
+                                                appArtifact: 'app-commcare-debug.apk',
+                                                testToRun: 'CALABASH',
+                                                calabashFeatures: 'aws/features.zip',
+                                                calabashTags: tag,
+                                                isRunUnmetered: true,
+                                                storeResults: true,
+                                            ])
+                            if (currentBuild.result == 'SUCCESS') {
+                                echo "Step ${stageString} set to SUCCESS"
+                                stagePassed = true
                             }
+                            count = count + 1
                         }
-                    } catch(error) {
-                        echo "Failed testing ${stageString}"
-                        currentBuild.result = 'FAILURE'
+                        if (!stagePassed) {
+                            echo "Build set to FAILURE after on step ${stageString}"
+                            buildPassing = false
+                        }
+                        currentBuild.result = "UNSET"
                     }
                 }
             }
+        }
         } finally {
+
+            if (buildPassing) {
+                currentBuild.result = 'SUCCESS'
+            } else {
+                currentBuild.result = 'FAILURE'
+            }
+
             if (notify) {
                 if (currentBuild.result == 'SUCCESS') {
                     slackSend color: 'good', message: 'Amazon device farm tests passed, :tight:'

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -7,7 +7,7 @@ def notify = false
 // Number of times to retry a failed test
 def retries = 3
 // Pool of devices on AWS to run on
-def poolArray = ['asus']
+def poolArray = ['galaxy']
 // Job to copy the tested APK from
 def cc_android_job = 'commcare-android'
 

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -48,7 +48,7 @@ node {
                                                     runName: stageString,
                                                     appArtifact: 'app-commcare-debug.apk',
                                                     testToRun: 'CALABASH',
-                                                    calabashFeatures: 'features.zip',
+                                                    calabashFeatures: 'aws/features.zip',
                                                     calabashTags: tag,
                                                     isRunUnmetered: true,
                                                     storeResults: true,

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -12,11 +12,10 @@ node {
 
         // All of the tags run on AWS. We specify these individually so that we can iterate over each
         // tag and retry them granularly when they fail.
-        //def tagArray = ['@MenuTests', '@Login', '@FormEntry', '@Fixtures', '@FormSettings',
-        //            '@Setup', '@CaseSharing', '@Languages',
-        //            '@CaseListSearch', '@CaseListSort', '@Settings', '@FormFiltering',
-        //            '@SessionExpiration', '@Dialogs']
-        def tagArray = ['@Fixtures']
+        def tagArray = ['@MenuTests', '@Login', '@FormEntry', '@Fixtures', '@FormSettings',
+                    '@Setup', '@CaseSharing', '@Languages',
+                    '@CaseListSearch', '@CaseListSort', '@Settings', '@FormFiltering',
+                    '@SessionExpiration', '@Dialogs']
         try {
             echo 'Running tests...'
             currentBuild.result = 'SUCCESS'

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,7 +1,3 @@
-stage('build') {
-    build job: 'commcare-odk-build-tests'
-}
-
 // Should send email/slack notification
 def notify = false
 // Number of times to retry a failed test

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -3,7 +3,7 @@ stage('build') {
 }
 
 // Should send email/slack notification
-def notify = true
+def notify = false
 // Number of times to retry a failed test
 def retries = 3
 // Pool of devices on AWS to run on

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -69,7 +69,7 @@ node {
                 }
             }
         }
-        } finally {
+        finally {
 
             if (buildPassing) {
                 currentBuild.result = 'SUCCESS'

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -12,11 +12,11 @@ node {
 
         // All of the tags run on AWS. We specify these individually so that we can iterate over each
         // tag and retry them granularly when they fail.
-        def tagArray = ['@MenuTests', '@Login', '@FormEntry', '@Fixtures', '@FormSettings',
-                    '@Setup', '@CaseSharing', '@Languages',
-                    '@CaseListSearch', '@CaseListSort', '@Settings', '@FormFiltering',
-                    '@SessionExpiration', '@Dialogs']
-
+        //def tagArray = ['@MenuTests', '@Login', '@FormEntry', '@Fixtures', '@FormSettings',
+        //            '@Setup', '@CaseSharing', '@Languages',
+        //            '@CaseListSearch', '@CaseListSort', '@Settings', '@FormFiltering',
+        //            '@SessionExpiration', '@Dialogs']
+        def tagArray = ['@Fixtures']
         try {
             echo 'Running tests...'
             currentBuild.result = 'SUCCESS'


### PR DESCRIPTION
The new Pipeline `step` command doesn't throw an exception on failure so the old `retry` pattern won't work. Needed to re-implement this using the global status variable. Not the best, but acceptable for now