### PR TITLE
Don't copy resources (videos, pics) from AWS Device Farm runs

### DIFF
--- a/scripts/RunnerJenkinsfile
+++ b/scripts/RunnerJenkinsfile
@@ -19,7 +19,7 @@ node {
                         calabashFeatures: 'aws/features.zip',
                         calabashTags: params.tag,
                         isRunUnmetered: true,
-                        storeResults: true,
+                        storeResults: false,
                         ignoreRunError: false,
                     ])
 }


### PR DESCRIPTION
Even just storing runs from the past 5 days, resources from Device Farm were taking up 25 GB (!). This doesn't copy those over so you have to navigate to Device Farm to watch videos/see the screen grabs (as I almost always did, anyways). 