### PR TITLE
Force portrait made during CCZ install

### DIFF
--- a/features/step_definitions/installation.rb
+++ b/features/step_definitions/installation.rb
@@ -11,6 +11,7 @@ end
 
 # peform offline install using ccz file pushed from repository
 Then (/^I install the ccz app at "([^\"]*)"$/) do |path|
+  perform_action('set_activity_orientation', 'portrait')
   wait_for_element_exists("* {text contains[c] 'Welcome to CommCare'}", timeout: 6000)
   press_menu_button()
   tap_when_element_exists("* {text CONTAINS[c] 'Offline install'}")


### PR DESCRIPTION
This should work around the Amazon Device Farm orientation issue