### PR TITLE
Remove retry touch

### DIFF
--- a/features/menu_tests.feature
+++ b/features/menu_tests.feature
@@ -97,7 +97,7 @@ Feature: Test all primary CommCare menu options
     Then I touch the "Wifi Direct" text
     Then I see the text "Do you want to send, receive, or submit forms?"
     Then I wait to see "Transfer"
-    Then I retry touch the "Transfer" text
+    Then I touch the "Transfer" text
     Then I verify that the current activity is "CommCareWiFiDirectActivity"
     Then I go back to the home screen
 

--- a/features/step_definitions/main_structure_steps.rb
+++ b/features/step_definitions/main_structure_steps.rb
@@ -168,11 +168,3 @@ Then (/^I robust touch the "([^\"]*)" text$/) do |text|
   tap_when_element_exists("* {text CONTAINS[c] '#{text}'}")
   step("I wait for 10 seconds")
 end
-
-Then (/^I retry touch the "([^\"]*)" text$/) do |text|
-  while true
-    break if (element_does_not_exist("* {text CONTAINS[c] '#{text}'}"))
-    touch("* {text CONTAINS[c] '#{text}'}")
-    sleep 1
-  end
-end


### PR DESCRIPTION
This was a dumb function (that I added) - the 'Transfer' text was on the screen under the button so this caused an infinite loop. 