### PR TITLE
Scroll to Start

### DIFF
--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -16,6 +16,7 @@ end
 
 Then (/^I press start$/) do
     hide_soft_keyboard()
+    step("I scroll until I see the \"Start\" text")
     wait_for_element_exists("* {text CONTAINS[c] 'Start'}'", timeout: 60)
     touch("android.support.v7.widget.CardView index:0")
     wait_for_element_exists("* id:'screen_suite_menu_list'", timeout: 60)

--- a/features/tiles.feature
+++ b/features/tiles.feature
@@ -4,8 +4,7 @@ Feature: Case Tiles
   Scenario: No tile
     Then I install the ccz app at "tiles.ccz"
     Then I login with username "tile.test" and password "123"
-    Then I scroll until I see the "Start" text
-    Then I touch the "Start" text
+    Then I press start
 
     Then I select module "NoPersist"
 
@@ -32,8 +31,7 @@ Feature: Case Tiles
 
   Scenario: Persistent Tile w/Dropdown
     Then I login with username "tile.test" and password "123"
-    Then I scroll until I see the "Start" text
-    Then I touch the "Start" text
+    Then I press start
 
     Then I select module "PersistentInline"
 
@@ -104,8 +102,7 @@ Feature: Case Tiles
     
   Scenario: Persistent w/Detail
     Then I login with username "tile.test" and password "123"
-    Then I scroll until I see the "Start" text
-    Then I touch the "Start" text
+    Then I press start
 
     Then I select module "PersistentWithDetail"
 
@@ -136,8 +133,7 @@ Feature: Case Tiles
 
   Scenario: Persistent no Detail no Inline
     Then I login with username "tile.test" and password "123"
-    Then I scroll until I see the "Start" text
-    Then I touch the "Start" text
+    Then I press start
 
     Then I select module "PersistentNoDetailNoInline"
 
@@ -161,8 +157,7 @@ Feature: Case Tiles
 
   Scenario: Breadcrumb
     Then I login with username "tile.test" and password "123"
-    Then I scroll until I see the "Start" text
-    Then I touch the "Start" text
+    Then I press start
 
     Then I select module "Breadcrumb"
 


### PR DESCRIPTION
Add scrolling to the start button so that in landscape mode this function will still work.

This error has been coming up and the fix was already incorporated into the `@CaseTiles` tests (looks like originally innovated by @ctsims )