### PR TITLE
Sleep after submitting

### DIFF
--- a/features/step_definitions/navigation.rb
+++ b/features/step_definitions/navigation.rb
@@ -123,6 +123,7 @@ Then (/^Submit/) do
   else
     tap_when_element_exists("* id:'nav_btn_next'")
   end
+  sleep 1
 end
 
 Then (/^Prev$/) do


### PR DESCRIPTION
Wait a second after submitting a form. AWS is giving ` java.lang.SecurityException: Injecting to another application requires INJECT_EVENTS permission (RuntimeError)` after submission on some tests and often the event firing too quickly is the cause