### PR TITLE
Sleep after rotating

### DIFF
--- a/features/step_definitions/installation.rb
+++ b/features/step_definitions/installation.rb
@@ -21,6 +21,7 @@ Then (/^I install the ccz app at "([^\"]*)"$/) do |path|
 
   # get around bug where the install button is disabled after entering text
   step("I rotate to landscape")
+  sleep 1
   step("I rotate to portrait")
   sleep 1
 
@@ -40,6 +41,7 @@ Then (/^I do an offline update to the ccz app at "([^\"]*)"$/) do |path|
 
   # get around bug where the install button is disabled after entering text
   step("I rotate to landscape")
+  sleep 1
   step("I rotate to portrait")
   sleep 1
 


### PR DESCRIPTION
On ADF the back-to-back rotates is causing the rotate back to portrait to be missed (I think) so add a sleep in between to wait for the action to complete