### PR TITLE
Fix For LogSubmissionTest

### DIFF
--- a/features/step_definitions/activity_steps.rb
+++ b/features/step_definitions/activity_steps.rb
@@ -1,3 +1,3 @@
 Then (/^I start "([^\"]*)" activity with extras "([^\"]*)"$/) do |activity, extra|
- system("adb shell am start -n " + "org.commcare.dalvik/org.commcare.activities." + activity + " " + extra)
+ system("adb shell am start -n " + "org.commcare.dalvik.debug/org.commcare.activities." + activity + " " + extra)
 end


### PR DESCRIPTION
* Corrects app id for debug build in activity_steps

Will, because of the recent appId change for debug builds,  Calabash was not able to find the required activity and start it. 