### PR TITLE
Revert back to using debug build

### DIFF
--- a/scripts/RunnerJenkinsfile
+++ b/scripts/RunnerJenkinsfile
@@ -6,7 +6,7 @@ node {
 
     step ([$class: 'CopyArtifact',
                   projectName: params.cc_android_job,
-                  filter: '**/app-commcare-release.apk',
+                  filter: '**/app-commcare-debug.apk',
                   fingerprintArtifacts: true,
                   flatten: true]);
 
@@ -14,7 +14,7 @@ node {
                         projectName: 'commcare-odk',
                         devicePoolName: params.pool,
                         runName: params.stageString,
-                        appArtifact: 'app-commcare-release.apk',
+                        appArtifact: 'app-commcare-debug.apk',
                         testToRun: 'CALABASH',
                         calabashFeatures: 'aws/features.zip',
                         calabashTags: params.tag,


### PR DESCRIPTION
Because the advanced settings require global privileges to be set on the release build and because this isn't automatable in Calabash due to barcode scanning we need to revert to using the debug build