### PR TITLE
Remove reset_between_scenarios check

### DIFF
--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -2,7 +2,7 @@ require 'calabash-android/management/app_installation'
 
 AfterConfiguration do |config|
   puts "Config #{config}"
-  ENV['RESET_BETWEEN_SCENARIOS'] =='0'
+  ENV['RESET_BETWEEN_SCENARIOS'] ='0'
   FeatureMemory.feature = nil
 end
 

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -14,10 +14,6 @@ Before do |scenario|
     else
       log 'First scenario in feature - reinstalling apps'
     end
-
-    uninstall_apps
-    install_app(ENV['TEST_APP_PATH'])
-    install_app(ENV['APP_PATH'])
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -9,18 +9,10 @@ Before do |scenario|
 
   feature = scenario.feature
   if FeatureMemory.feature != feature
-    if ENV['RESET_BETWEEN_SCENARIOS'] == '1'
-      log 'New scenario - reinstalling apps'
-    else
-      log 'First scenario in feature - reinstalling apps'
-    end
+    log "Feature memory feature ${FeatureMemory.feature}, scenario feature ${scenario.feature}"
 
-    if not application_installed?(ENV['TEST_APP_PATH'])
-      install_app(ENV['TEST_APP_PATH'])
-    end
-    if not application_installed?(ENV['APP_PATH'])
-      install_app(ENV['APP_PATH'])
-    end
+    ensure_app_installed
+
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -1,6 +1,8 @@
 require 'calabash-android/management/app_installation'
 
 AfterConfiguration do |config|
+  puts "Config #{config}"
+  ENV['RESET_BETWEEN_SCENARIOS'] =='0'
   FeatureMemory.feature = nil
 end
 
@@ -9,7 +11,7 @@ Before do |scenario|
 
   feature = scenario.feature
   if FeatureMemory.feature != feature
-    log "This is just a test log"
+    puts("This is just a test log")
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -8,7 +8,7 @@ Before do |scenario|
   scenario = scenario.scenario_outline if scenario.respond_to?(:scenario_outline)
 
   feature = scenario.feature
-  if FeatureMemory.feature != feature || ENV['RESET_BETWEEN_SCENARIOS'] == '1'
+  if FeatureMemory.feature != feature
     if ENV['RESET_BETWEEN_SCENARIOS'] == '1'
       log 'New scenario - reinstalling apps'
     else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -9,10 +9,18 @@ Before do |scenario|
 
   feature = scenario.feature
   if FeatureMemory.feature != feature
-    log "Feature memory feature ${FeatureMemory.feature}, scenario feature ${scenario.feature}"
+    if ENV['RESET_BETWEEN_SCENARIOS'] == '1'
+      log 'New scenario - reinstalling apps'
+    else
+      log 'First scenario in feature - reinstalling apps'
+    end
 
-    ensure_app_installed
-
+    if not application_installed?(ENV['TEST_APP_PATH'])
+      install_app(ENV['TEST_APP_PATH'])
+    end
+    if not application_installed?(ENV['APP_PATH'])
+      install_app(ENV['APP_PATH'])
+    end
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -14,13 +14,6 @@ Before do |scenario|
     else
       log 'First scenario in feature - reinstalling apps'
     end
-
-    if not application_installed?(ENV['TEST_APP_PATH'])
-      install_app(ENV['TEST_APP_PATH'])
-    end
-    if not application_installed?(ENV['APP_PATH'])
-      install_app(ENV['APP_PATH'])
-    end
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -9,11 +9,7 @@ Before do |scenario|
 
   feature = scenario.feature
   if FeatureMemory.feature != feature
-    if ENV['RESET_BETWEEN_SCENARIOS'] == '1'
-      log 'New scenario - reinstalling apps'
-    else
-      log 'First scenario in feature - reinstalling apps'
-    end
+    log "This is just a test log"
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/features/support/app_installation_hooks.rb
+++ b/features/support/app_installation_hooks.rb
@@ -14,6 +14,13 @@ Before do |scenario|
     else
       log 'First scenario in feature - reinstalling apps'
     end
+
+    if not application_installed?(ENV['TEST_APP_PATH'])
+      install_app(ENV['TEST_APP_PATH'])
+    end
+    if not application_installed?(ENV['APP_PATH'])
+      install_app(ENV['APP_PATH'])
+    end
     FeatureMemory.feature = feature
     FeatureMemory.invocation = 1
   else

--- a/scripts/RunnerJenkinsfile
+++ b/scripts/RunnerJenkinsfile
@@ -19,7 +19,7 @@ node {
                         calabashFeatures: 'features.zip',
                         calabashTags: params.tag,
                         isRunUnmetered: true,
-                        storeResults: false,
+                        storeResults: true,
                         ignoreRunError: false,
                     ])
 }


### PR DESCRIPTION
In this hook the primary work is done on these three lines:

```    
uninstall_apps
install_app(ENV['TEST_APP_PATH'])
install_app(ENV['APP_PATH'])
```

What this does is uninstall the apps (CommCare and the test server) and reinstall them. We do this in two conditions: when we have a new feature (IE we've moved to a new test file) OR when this environment variable (the same on mentioned on the Device Farm forum but in a different context) is set to `1`. However, I think we only need to perform this re-installing when we run a new feature - there's no reason to reset every time as the app data seems to be cleared on its own. I think re-installing the test server was causing the HTTPDisconnect error on AWS. 

Tellingly, after making this change I *only* see the HTTPDisconnectError on the first run of of the new feature (IE when we would be running the uninstall/reinstall command). I'm going to try replacing this with [`clear_app_data`](https://github.com/calabash/calabash-android/blob/master/ruby-gem/lib/calabash-android/operations.rb#L139) 