### PR TITLE
Fixes application id for intent broadcasts

### DIFF
--- a/features/step_definitions/adb_steps.rb
+++ b/features/step_definitions/adb_steps.rb
@@ -19,7 +19,7 @@ Then (/^I broadcast image attachment with file path "([^\"]*)"$/) do |file_path|
 end
 
 def receiver_command(action)
-    return "adb shell am broadcast -a #{action} -n org.commcare.dalvik.debug/org.commcare.provider.DebugControlsReceiver"
+    return "adb shell am broadcast -a #{action} -n #{getApplicationId}/org.commcare.provider.DebugControlsReceiver"
 end
 
 def clear_restore_cache()


### PR DESCRIPTION
This should fix @FormAttacheentUpload test failures.